### PR TITLE
add `lockdown` to the denylist

### DIFF
--- a/content.js
+++ b/content.js
@@ -78,6 +78,7 @@ function setup() {
         'orona',
         'irus',
         'uarantin',
+        'ockdown',
         'andemic'
     ];
 


### PR DESCRIPTION
Track `lockdown` in the denylist as articles about Covid-19 sometimes just refer to that.